### PR TITLE
minor polish in ?src database

### DIFF
--- a/lambdabot/State/source
+++ b/lambdabot/State/source
@@ -1001,7 +1001,7 @@ writeSTRef (STRef var#) val = ST $ \s1# ->
     case writeMutVar# var# val s1#      of { s2# ->
         (# s2#, () #) }
 
-STRef ==
+STRef (==)
 STRef v1# == STRef v2# = sameMutVar# v1# v2#
 
 Eq


### PR DESCRIPTION
Other operators in ?src's database use Haskell's standard of using parentheses.
