### PR TITLE
lambdabot-core: add support for 'CODEPAGE' server command

### DIFF
--- a/lambdabot-core/src/Lambdabot/Bot.hs
+++ b/lambdabot-core/src/Lambdabot/Bot.hs
@@ -14,6 +14,7 @@ module Lambdabot.Bot
     , checkPrivs
     , checkIgnore
     
+    , ircCodepage
     , ircGetChannels
     , ircQuit
     , ircReconnect
@@ -137,6 +138,13 @@ checkIgnore msg = liftM2 (&&) (liftM not (checkPrivs msg))
 
 ------------------------------------------------------------------------
 -- Some generic server operations
+
+-- Send a CODEPAGE command to set encoding for current session.
+-- Some IRC networks don't provide UTF-8 ports, but allow
+-- switching it in runtime
+ircCodepage :: String -> String -> LB ()
+ircCodepage svr cpage = do
+    send $ codepage svr cpage
 
 ircGetChannels :: LB [Nick]
 ircGetChannels = (map getCN . M.keys) `fmap` gets ircChannels

--- a/lambdabot-core/src/Lambdabot/IRC.hs
+++ b/lambdabot-core/src/Lambdabot/IRC.hs
@@ -8,6 +8,7 @@ module Lambdabot.IRC
     , partChannel
     , getTopic
     , setTopic
+    , codepage
     , privmsg
     , quit
     , timeReply
@@ -85,6 +86,11 @@ privmsg who msg = if action then mk [nName who, ':':(chr 0x1):("ACTION " ++ clea
           (clean_msg,action) = case cleaned_msg of
               ('/':'m':'e':r) -> (dropWhile isSpace r,True)
               str             -> (str,False)
+
+-- | 'codepage' creates a server CODEPAGE message. The input string given is the
+--   codepage name for current session.
+codepage :: String -> String -> IrcMessage
+codepage svr codepage = mkMessage svr "CODEPAGE" [' ':codepage]
 
 -- | 'quit' creates a server QUIT message. The input string given is the
 --   quit message, given to other parties when leaving the network.

--- a/lambdabot-core/src/Lambdabot/Plugin/Core/System.hs
+++ b/lambdabot-core/src/Lambdabot/Plugin/Core/System.hs
@@ -89,6 +89,13 @@ systemPlugin = newModule
                 tgtNick <- readNick tgt
                 lb $ ircPrivmsg tgtNick txt
             }
+        , (command "codepage")
+            { privileged = True
+            , help = say "codepage <server> <CP-name>"
+            , process = \rest -> do
+                let (server, cp) = splitFirstWord rest
+                lb $ ircCodepage server cp
+            }
         , (command "quit")
             { privileged = True
             , help = say "quit [msg], have the bot exit with msg"


### PR DESCRIPTION
Our network uses CP1251, KOI8-R IRC ports and does
 not have ports with default UTF-8.

  But has 'CODEPAGE UTF-8' command.

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
