### PR TITLE
build fix for ghc-7.8: satisfy role constraints

### DIFF
--- a/lambdabot-core/src/Lambdabot/Monad.hs-boot
+++ b/lambdabot-core/src/Lambdabot/Monad.hs-boot
@@ -1,5 +1,12 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
+#if __GLASGOW_HASKELL__ > 706
+{-# LANGUAGE RoleAnnotations #-}
+#endif
 module Lambdabot.Monad where
 
+#if __GLASGOW_HASKELL__ > 706
+type role LB nominal
+#endif
 data LB a
 instance Monad LB


### PR DESCRIPTION
Unfortunately, a nominal role is inferred for the type a in

  newtype ReaderT r m a = ReaderT (r -> m a)

causing a conflict between the declarations of LB in Monad.hs
and Monad.hs-boot. The fix is declare the nominal role
explicitly in the hs-boot file.
