### PR TITLE
Updating Monad.hs-boot to work with ghc 7.8.2 & cabal 1.20.0.2

### DIFF
--- a/lambdabot-core/src/Lambdabot/Monad.hs-boot
+++ b/lambdabot-core/src/Lambdabot/Monad.hs-boot
@@ -1,5 +1,9 @@
 {-# LANGUAGE RankNTypes #-}
 module Lambdabot.Monad where
+import Control.Monad.Reader
+import Data.IORef
 
-data LB a
+data IRCRWState
+data IRCRState
+newtype LB a = LB {runLB :: ReaderT (IRCRState, IORef IRCRWState) IO a} 
 instance Monad LB


### PR DESCRIPTION
With ghc 7.8.2 & cabal 1.20.0.2 I was getting the following error : 

``` haskell
src/Lambdabot/Monad.hs-boot:4:1:
    Type constructor ‘LB’ has conflicting definitions in the module
    and its hs-boot file

    Main module: type role LB nominal
                 newtype LB a
                   = LB {runLB :: ReaderT (IRCRState, IORef IRCRWState) IO a}
    Boot file:   data LB a

cabal: Error: some packages failed to install:
lambdabot-4.3.0.1 failed during the building phase. The exception was:
ExitFailure 1
```

The modifications to `Monad.hs-boot` fix the error.
