### PR TITLE
Fix broken build on Windows.

### DIFF
--- a/lambdabot-core/lambdabot-core.cabal
+++ b/lambdabot-core/lambdabot-core.cabal
@@ -95,6 +95,8 @@ library
                         template-haskell        >= 2.7,
                         transformers            >= 0.2,
                         transformers-base       >= 0.4,
-                        unix                    >= 2.5,
                         utf8-string             >= 0.3,
                         zlib                    >= 0.5
+
+  if !os(windows)
+    build-depends:      unix                    >= 2.5

--- a/lambdabot-core/src/Lambdabot/Util/Signals.hs
+++ b/lambdabot-core/src/Lambdabot/Util/Signals.hs
@@ -21,8 +21,10 @@ import Control.Exception (Exception)
 
 #ifdef mingw32_HOST_OS
 
+import Control.Monad.Trans.Control
+
 type Signal = String
-newtype SignalException = SignalException Signal deriving Typeable
+newtype SignalException = SignalException Signal deriving (Show, Typeable)
 instance Exception SignalException
 
 ircSignalMessage :: Signal -> [Char]


### PR DESCRIPTION
The Windows build appears to have bit rotted.  This fixes the only error encountered when building with Platform 2013.2.0.0.