### PR TITLE
Fix version of haskell-src-exts in lambdabot-haskell-plugins

### DIFF
--- a/lambdabot-haskell-plugins/lambdabot-haskell-plugins.cabal
+++ b/lambdabot-haskell-plugins/lambdabot-haskell-plugins.cabal
@@ -71,7 +71,7 @@ library
                         containers              >= 0.4,
                         directory               >= 1.1,
                         filepath                >= 1.3,
-                        haskell-src-exts        >= 1.14.0,
+                        haskell-src-exts        >= 1.14.0 && < 1.16.0,
                         lambdabot-core          >= 5,
                         lifted-base             >= 0.2,
                         mtl                     >= 2,


### PR DESCRIPTION
There were breaking changes in the API in version 1.16.0, and lambdabot doesn't compile with that version until someone fixes it.