### PR TITLE
Include lambdabot-trusted in travis build process.

### DIFF
--- a/.travis/build
+++ b/.travis/build
@@ -2,7 +2,7 @@
 
 set -e
 
-for dir in lambdabot-core lambdabot-*-plugins lambdabot; do
+for dir in lambdabot-core lambdabot-*-plugins lambdabot lambdabot-trusted; do
     (cd "$dir" && cabal install)
 done
 


### PR DESCRIPTION
This pull request adds `lambdabot-trusted` to the travis build.