### PR TITLE
haskell-src-exts 1.16 renames UnGuardedAlt

### DIFF
--- a/lambdabot-haskell-plugins/lambdabot-haskell-plugins.cabal
+++ b/lambdabot-haskell-plugins/lambdabot-haskell-plugins.cabal
@@ -71,7 +71,7 @@ library
                         containers              >= 0.4,
                         directory               >= 1.1,
                         filepath                >= 1.3,
-                        haskell-src-exts        >= 1.14.0,
+                        haskell-src-exts        >= 1.14.0 && < 1.16.0,
                         lambdabot-core          >= 5,
                         lifted-base             >= 0.2,
                         mtl                     >= 2,


### PR DESCRIPTION
According to the changelog:

```
* GuardedAlt and GuardedAlts types are replaced with the isomorphic
  GuardedRhs and Rhs types
```

For now, just place an upper bound here.