### PR TITLE
Shorten the "x @more lines" limit to 3

### DIFF
--- a/lambdabot-core/src/Lambdabot/Plugin/Core/More.hs
+++ b/lambdabot-core/src/Lambdabot/Plugin/Core/More.hs
@@ -43,4 +43,4 @@ moreFilter target msglines = do
                           then []
                           else ['[':shows (length morelines) " @more lines]"]
 
-    where maxLines = 5 -- arbitrary, really
+    where maxLines = 3 -- arbitrary, really


### PR DESCRIPTION
As some people have complained (including shachaf) the output of 5 lines is quite long, especially since it is usually shown on non-interesting errors.
