### PR TITLE
cabal file: fix compilation error when monad-control is >= 1.0 by limiting it to < 1.0

### DIFF
--- a/lambdabot-core/lambdabot-core.cabal
+++ b/lambdabot-core/lambdabot-core.cabal
@@ -81,7 +81,7 @@ library
                         hslogger                >= 1.2.1,
                         HTTP                    >= 4000,
                         lifted-base             >= 0.2,
-                        monad-control           >= 0.3,
+                        monad-control           >= 0.3 && < 1.0.0.0,
                         mtl                     >= 2,
                         network                 >= 2.3.0.13,
                         time                    >= 1.4,


### PR DESCRIPTION
Otherwise, it doesn't build anymore.

see also https://github.com/agrafix/Spock/issues/20
