### PR TITLE
@type: ignore ~/.ghci for interpreter session.

### DIFF
--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Type.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Type.hs
@@ -133,7 +133,7 @@ query_ghci cmd expr = do
         extFlags = ["-X" ++ ext | ext <- exts]
     ghci <- getConfig ghciBinary
     (_, output, errors) <- io $ readProcessWithExitCode ghci
-        ("-v0":"-fforce-recomp":"-iState":extFlags)
+        ("-v0":"-fforce-recomp":"-iState":"-ignore-dot-ghci":extFlags)
         (context ++ theCommand cmd (stripComments (decodeString expr)))
     let ls = extract_signatures output
     return $ case ls of


### PR DESCRIPTION
When setting up lambdabot, using the type plugin yielded some unexpected results for me, which I could track down to it running ghci without `-ignore-dot-ghci`. Should this switch be added by default? It caught  me by surprise that configs for interactive use were sourced.