### PR TITLE
Add support for server auto-reconnection and channels auto-rejoin

### DIFF
--- a/lambdabot-core/src/Lambdabot/Bot.hs
+++ b/lambdabot-core/src/Lambdabot/Bot.hs
@@ -154,7 +154,7 @@ ircGetChannels = (map getCN . M.keys) `fmap` gets ircChannels
 -- exceptoin, we clean up and go home
 ircQuit :: String -> String -> LB ()
 ircQuit svr msg = do
-    modify $ \state' -> state' { ircStayConnected = False }
+    modify $ \state' -> state' { ircPersists = M.delete svr $ ircPersists state' }
     send  $ quit svr msg
     liftIO $ threadDelay 1000
     noticeM "Quitting"

--- a/lambdabot-core/src/Lambdabot/Bot.hs
+++ b/lambdabot-core/src/Lambdabot/Bot.hs
@@ -161,6 +161,7 @@ ircQuit svr msg = do
 
 ircReconnect :: String -> String -> LB ()
 ircReconnect svr msg = do
+    modify $ \state' -> state' { ircPersists = M.insertWith (flip const) svr False $ ircPersists state' }
     send $ quit svr msg
     liftIO $ threadDelay 1000
 

--- a/lambdabot-core/src/Lambdabot/Monad.hs
+++ b/lambdabot-core/src/Lambdabot/Monad.hs
@@ -112,6 +112,8 @@ data IRCRWState = IRCRWState
     
     , ircChannels        :: M.Map ChanName String
     -- ^ maps channel names to topics
+    , ircPersists        :: M.Map String Bool
+    -- ^ lists servers to which try to reconnect on failure (one-time or always)
     
     , ircModules         :: M.Map String ModuleRef
     , ircCallbacks       :: M.Map String [(String,Callback)]
@@ -119,7 +121,6 @@ data IRCRWState = IRCRWState
     -- ^ Output filters, invoked from right to left
     
     , ircCommands        :: M.Map String CommandRef
-    , ircStayConnected   :: !Bool
     }
 
 -- | Default rw state
@@ -128,6 +129,7 @@ initRwState = IRCRWState
     { ircPrivilegedUsers = S.singleton (Nick "offlinerc" "null")
     , ircIgnoredUsers    = S.empty
     , ircChannels        = M.empty
+    , ircPersists        = M.empty
     , ircModules         = M.empty
     , ircServerMap       = M.empty
     , ircCallbacks       = M.empty
@@ -137,7 +139,6 @@ initRwState = IRCRWState
         , ([],cleanOutput)
         ]
     , ircCommands        = M.empty
-    , ircStayConnected   = True
     }
 
 

--- a/lambdabot-core/src/Lambdabot/Plugin/Core/Base.hs
+++ b/lambdabot-core/src/Lambdabot/Plugin/Core/Base.hs
@@ -139,6 +139,12 @@ doRPL_WELCOME msg
                                             then ircPersists state'
                                             else M.delete (server msg) $ ircPersists state'
                              in state' { ircPersists = persists }
+         chans <- gets ircChannels
+         forM_ (M.keys chans) $ \chan -> do
+             let cn = getCN chan
+             when (nTag cn == server msg) $ do
+                 modify $ \state' -> state' { ircChannels = M.delete chan $ ircChannels state' }
+                 lb $ send $ joinChannel cn
 
 doQUIT :: Callback
 doQUIT msg = doIGNORE msg

--- a/lambdabot-core/src/Lambdabot/Plugin/Core/Base.hs
+++ b/lambdabot-core/src/Lambdabot/Plugin/Core/Base.hs
@@ -134,7 +134,11 @@ doTOPIC msg
          put (s { ircChannels = M.insert (mkCN loc) (tail $ head $ tail $ ircMsgParams msg) (ircChannels s)})
 
 doRPL_WELCOME :: Callback
-doRPL_WELCOME = doIGNORE
+doRPL_WELCOME msg
+    = do modify $ \state' -> let persists = if M.findWithDefault True (server msg) (ircPersists state')
+                                            then ircPersists state'
+                                            else M.delete (server msg) $ ircPersists state'
+                             in state' { ircPersists = persists }
 
 doQUIT :: Callback
 doQUIT msg = doIGNORE msg

--- a/lambdabot-core/src/Lambdabot/Plugin/Core/System.hs
+++ b/lambdabot-core/src/Lambdabot/Plugin/Core/System.hs
@@ -103,6 +103,13 @@ systemPlugin = newModule
                 server <- getServer
                 lb (ircQuit server $ if null rest then "requested" else rest)
             }
+        , (command "disconnect")
+            { privileged = True
+            , help = say "disconnect <server> [msg], disconnect from a server with msg"
+            , process = \rest -> do
+                let (server, msg) = splitFirstWord rest
+                lb (ircQuit server $ if null msg then "requested" else msg)
+            }
         , (command "flush")
             { privileged = True
             , help = say "flush. flush state to disk"

--- a/lambdabot-core/src/Lambdabot/Plugin/Core/System.hs
+++ b/lambdabot-core/src/Lambdabot/Plugin/Core/System.hs
@@ -123,7 +123,7 @@ systemPlugin = newModule
             , help = say "reconnect to server"
             , process = \rest -> do
                 server <- getServer
-                lb (ircReconnect server $ if null rest then "requested" else rest)
+                lb (ircReconnect server $ if null rest then "reconnect requested" else rest)
             }
         ]
     }

--- a/lambdabot-irc-plugins/lambdabot-irc-plugins.cabal
+++ b/lambdabot-irc-plugins/lambdabot-irc-plugins.cabal
@@ -39,7 +39,8 @@ library
 
   exposed-modules:      Lambdabot.Plugin.IRC
 
-  other-modules:        Lambdabot.Plugin.IRC.IRC
+  other-modules:        Lambdabot.Config.IRC
+                        Lambdabot.Plugin.IRC.IRC
                         Lambdabot.Plugin.IRC.Localtime
                         Lambdabot.Plugin.IRC.Log
                         Lambdabot.Plugin.IRC.Topic

--- a/lambdabot-irc-plugins/src/Lambdabot/Config/IRC.hs
+++ b/lambdabot-irc-plugins/src/Lambdabot/Config/IRC.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-overlapping-patterns #-}
+module Lambdabot.Config.IRC
+    ( reconnectDelay
+    ) where
+
+import Lambdabot.Config
+
+config "reconnectDelay" [t| Int |] [| 10000000 |]

--- a/lambdabot-irc-plugins/src/Lambdabot/Plugin/IRC/IRC.hs
+++ b/lambdabot-irc-plugins/src/Lambdabot/Plugin/IRC/IRC.hs
@@ -180,7 +180,7 @@ online tag hostn portnum nickn ui = do
           io $ SSem.signal ready
           delay <- getConfig reconnectDelay
           let retry = do
-              continue <- lift $ gets (M.member tag . ircPersists)
+              continue <- lift $ gets $ \st -> (M.member tag $ ircPersists st) && not (M.member tag $ ircServerMap st)
               if continue
                   then do
                       E.catch online'

--- a/lambdabot-irc-plugins/src/Lambdabot/Plugin/IRC/IRC.hs
+++ b/lambdabot-irc-plugins/src/Lambdabot/Plugin/IRC/IRC.hs
@@ -7,6 +7,7 @@ import Lambdabot.Logging
 import Lambdabot.Monad
 import Lambdabot.Plugin
 import Lambdabot.Util
+import Lambdabot.Config.IRC
 
 import Control.Concurrent.Lifted
 import qualified Control.Concurrent.SSem as SSem
@@ -177,6 +178,7 @@ online tag hostn portnum nickn ui = do
           io $ SSem.wait fin
           void $ lb $ remServer tag
           io $ SSem.signal ready
+          delay <- getConfig reconnectDelay
           let retry = do
               continue <- lift $ gets (M.member tag . ircPersists)
               if continue
@@ -184,7 +186,7 @@ online tag hostn portnum nickn ui = do
                       E.catch online'
                           (\e@SomeException{} -> do
                               errorM (show e)
-                              io $ threadDelay 10000000
+                              io $ threadDelay delay
                               retry
                           )
                   else do

--- a/lambdabot-irc-plugins/src/Lambdabot/Plugin/IRC/IRC.hs
+++ b/lambdabot-irc-plugins/src/Lambdabot/Plugin/IRC/IRC.hs
@@ -43,6 +43,17 @@ ircPlugin = newModule
                         lift (online tag hostn pn nickn (intercalate " " uix))
                     _ -> say "Not enough parameters!"
             }
+        , (command "irc-persist-connect")
+            { privileged = True
+            , help = say "irc-persist-connect tag host portnum nickname userinfo.  connect to an irc server and reconnect on network failures"
+            , process = \rest ->
+                case splitOn " " rest of
+                    tag:hostn:portn:nickn:uix -> do
+                        pn <- (PortNumber . fromInteger) `fmap` readM portn
+                        lift (online tag hostn pn nickn (intercalate " " uix))
+                        lift $ lift $ modify $ \state' -> state' { ircPersists = M.insert tag True $ ircPersists state' }
+                    _ -> say "Not enough parameters!"
+            }
         , (command "irc-password")
             { privileged = True
             , help = say "irc-password pwd.  set password for next irc-connect command"


### PR DESCRIPTION
This set of changes:

1. Adds infrastructure for "persistent servers" (i.e. servers which we try to reconnect on failure). "Persistence" can be one-time (reconnect once) or lasting (reconnect always). Reconnection would be tried indefinitely with a 10s wait between retries. it can be stopped with a new command "disconnect" (see below).
2. Uses it instead of `ircStayConnected` to stop offlinerc.
3. Uses `ircChannels` which we now also properly clean up to rejoin channels after reconnection.
4. Makes "irc-connect" more synchronous -- now it doesn't return until RPL_WELCOME is received, which allows one to use "join" right after "irc-connect" in startup scripts.

I've added two new commands to avoid changing existing ones:

* "irc-persist-connect" acts like "irc-connect" but flags server as persistent (arguably this can be the default behavior or an additional argument to "irc-connect" instead, but I've avoided changing syntax/semantics of existing commands as much as possible).
* "disconnect" acts as "quit" but expects server name as the first argument, allowing one to disconnect lambdabot off one server from the other (or from offlinerc).

Some commands now behave a little different:

* "reconnect" now actually works, using new infrastructure.
* "irc-connect" waits till RPL_WELCOME is received.
* "quit" doesn't stop offlinerc when issued from on an IRC -- this was a bug.
* "quit" (and "disconnect") also remove server from "persistent servers" list, so they can be used to stop reconnection attempts.

Rationale for these changes:

I'm keeping lambdabot on a home server; Internet connection can be unreliable sometimes, and I'd like to avoid manual steps required to restore the bot after a network failure. The synchronous irc-connect change is to avoid issuing join commands manually after starting a bot. As a whole this allows me to have a systemd service which starts lambdabot with a provided startup script; to start the bot and join all needed channels it's now enough to just start the service, and with automatic reconnection this doesn't require maintenance after network problems.