### PR TITLE
fix unmtl's handling of transformer stacks

### DIFF
--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/UnMtl.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/UnMtl.hs
@@ -177,6 +177,7 @@ mtlParser' t@(TyCon (UnQual (Ident v))) = case lookup v types of
      Just pt -> pt t
      Nothing -> return t
 mtlParser' (TyApp a b) = mtlParser' a $$ mtlParser' b
+mtlParser' (TyParen t) = mtlParser' t
 mtlParser' t = return t
 
 -----------------------------------------------------------


### PR DESCRIPTION
Sample old behavior:

    lambdabot> unmtl ContT ByteString (StateT s IO) a
    (a -> (StateT s IO) ByteString) -> (StateT s IO) ByteString
    lambdabot> unmtl StateT s (ContT ByteString IO) a
    s -> (ContT ByteString IO) (a, s)
    lambdabot> unmtl ErrorT ByteString (WriterT String (State s)) a
    (WriterT String (State s)) (Either ByteString a)

As you can see, many mtl transformers remain in the results. Sample new behavior:

    lambdabot> unmtl ContT ByteString (StateT s IO) a
    (a -> s -> IO (ByteString, s)) -> s -> IO (ByteString, s)
    lambdabot> unmtl StateT s (ContT ByteString IO) a
    s -> (a -> s -> IO ByteString) -> IO ByteString
    lambdabot> unmtl ErrorT ByteString (WriterT String (State s)) a
    s -> (Either ByteString a, String, s)