### PR TITLE
Move default modules list to a separate binding

### DIFF
--- a/lambdabot/src/Modules.hs
+++ b/lambdabot/src/Modules.hs
@@ -13,11 +13,15 @@ import Lambdabot.Plugin.Novelty
 import Lambdabot.Plugin.Reference
 import Lambdabot.Plugin.Social
 
-modulesInfo :: Modules
-modulesInfo = $(modules $ corePlugins
+defaultModules :: [String]
+defaultModules =
+    corePlugins
     ++ haskellPlugins
     ++ ["irc", "localtime", "topic"] -- ircPlugins
     ++ ["dummy", "fresh", "todo"] -- miscPlugins
     ++ ["bf", "dice", "elite", "filter", "quote", "slap", "unlambda", "vixen"] -- noveltyPlugins
     ++ referencePlugins
-    ++ socialPlugins)
+    ++ socialPlugins
+
+modulesInfo :: Modules
+modulesInfo = $(modules defaultModules)


### PR DESCRIPTION
When building `lambdabot` in NixOS we have an option to specify a module list instead of a default, which is implemented with `sed` and a small patch. This small change should make our patching more reliable and allow people to specify e.g. `defaultModules ++ ["something"]`.

(Sorry, hit Send accidentially)