### PR TITLE
[lambdabot-haskell-plugins] Support haskell-src-exts-1.17.1

### DIFF
--- a/lambdabot-haskell-plugins/lambdabot-haskell-plugins.cabal
+++ b/lambdabot-haskell-plugins/lambdabot-haskell-plugins.cabal
@@ -98,7 +98,7 @@ library
                         containers              >= 0.4,
                         directory               >= 1.1,
                         filepath                >= 1.3,
-                        haskell-src-exts        >= 1.16.0,
+                        haskell-src-exts        >= 1.17.0,
                         lambdabot-core          >= 5.0.3 && < 5.1,
                         lambdabot-reference-plugins >= 5.0.3 && < 5.1,
                         lifted-base             >= 0.2,

--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Pointful.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Pointful.hs
@@ -54,11 +54,11 @@ succAlpha []       = "a"
 
 -- move lambda patterns into LHS
 optimizeD :: Decl -> Decl
-optimizeD (PatBind locat (PVar fname) (UnGuardedRhs (Lambda _ pats rhs)) (BDecls []))
-        =  FunBind [Match locat fname pats Nothing (UnGuardedRhs rhs) (BDecls [])]
+optimizeD (PatBind locat (PVar fname) (UnGuardedRhs (Lambda _ pats rhs)) Nothing)
+        =  FunBind [Match locat fname pats Nothing (UnGuardedRhs rhs) Nothing]
 ---- combine function binding and lambda
-optimizeD (FunBind [Match locat fname pats1 Nothing (UnGuardedRhs (Lambda _ pats2 rhs)) (BDecls [])])
-        =  FunBind [Match locat fname (pats1 ++ pats2) Nothing (UnGuardedRhs rhs) (BDecls [])]
+optimizeD (FunBind [Match locat fname pats1 Nothing (UnGuardedRhs (Lambda _ pats2 rhs)) Nothing])
+        =  FunBind [Match locat fname (pats1 ++ pats2) Nothing (UnGuardedRhs rhs) Nothing]
 optimizeD x = x
 
 -- remove parens
@@ -174,7 +174,7 @@ combinators = M.fromList $ map declToTuple defs
   where defs = case parseModule combinatorModule of
           ParseOk (Hs.Module _ _ _ _ _ _ d) -> d
           f@(ParseFailed _ _) -> error ("Combinator loading: " ++ show f)
-        declToTuple (PatBind _ (PVar fname) (UnGuardedRhs body) (BDecls []))
+        declToTuple (PatBind _ (PVar fname) (UnGuardedRhs body) Nothing)
           = (UnQual fname, Paren body)
         declToTuple _ = error "Pointful Plugin error: can't convert declaration to tuple"
 

--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Pretty.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Pretty.hs
@@ -73,7 +73,7 @@ doPretty (Hs.Module _ _ _ _ _ _ decls) =
             caseIndent   = 4,
             onsideIndent = 0
         }
-        prettyDecl (PatBind _ (PVar (Ident "__expr__")) (UnGuardedRhs e) (BDecls [])) -- pretty printing an expression
+        prettyDecl (PatBind _ (PVar (Ident "__expr__")) (UnGuardedRhs e) Nothing) -- pretty printing an expression
                      = prettyPrintWithMode (makeModeExp e) e
         prettyDecl d = prettyPrintWithMode (makeMode d) d
     -- TODO: prefixing with hashes is done, because i didn't find a way

--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Undo.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Undo.hs
@@ -54,7 +54,7 @@ undo v (Do stms) = f stms
                                             (var "fail")
                                             (Lit $ String "")
                                     ]
-        where alt pat x = Alt s pat (UnGuardedRhs x) (BDecls [])
+        where alt pat x = Alt s pat (UnGuardedRhs x) Nothing
     f _ = error "Undo plugin error: can't undo!"
 undo v (ListComp e stms) = f stms
  where
@@ -69,7 +69,7 @@ undo v (ListComp e stms) = f stms
                                     [ alt p (f xs)
                                     , alt PWildCard nil
                                     ]
-        where alt pat x = Alt s pat (UnGuardedRhs x) (BDecls [])
+        where alt pat x = Alt s pat (UnGuardedRhs x) Nothing
               concatMap' fun = App (App (var "concatMap") (Paren fun)) l
     f _ = error "Undo plugin error: can't undo!"
 undo _ x           = x
@@ -103,8 +103,8 @@ do' v e@(InfixApp l (QVarOp (UnQual (Symbol op))) r) =
              case r of
                  (Lambda loc [p] (Do stms)) -> Do (Generator loc p l : stms)
                  (Lambda loc [PVar v1] (Case (Var (UnQual v2))
-                                            [ Alt _ p (UnGuardedRhs s) (BDecls [])
-                                            , Alt _ PWildCard (UnGuardedRhs (App (Var (UnQual (Ident "fail"))) _)) (BDecls [])
+                                            [ Alt _ p (UnGuardedRhs s) Nothing
+                                            , Alt _ PWildCard (UnGuardedRhs (App (Var (UnQual (Ident "fail"))) _)) Nothing
                                             ]))
                            | v1 == v2           -> case s of
                                                        Do stms -> Do (Generator loc p l : stms)


### PR DESCRIPTION
Only difference seemed to be in the new treatment of `where` clauses. Before, `BDecls []` was used both for a missing `where` clause and an empty one. Now `Nothing` is used for missing clauses, and `BDecls []` for an empty one.