### PR TITLE
Add Data.Functor to lambdabot's default imports

### DIFF
--- a/lambdabot/State/Pristine.hs.default
+++ b/lambdabot/State/Pristine.hs.default
@@ -46,6 +46,7 @@ import Data.Dynamic
 import Data.Either
 import Data.Eq
 import Data.Function
+import Data.Functor
 import Data.Int
 import Data.List
 import Data.Maybe


### PR DESCRIPTION
So that we'd have `$>` available.