### PR TITLE
Added -XTypeApplications to pristine

### DIFF
--- a/lambdabot/State/Pristine.hs.default
+++ b/lambdabot/State/Pristine.hs.default
@@ -24,6 +24,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UnboxedTuples #-}


### PR DESCRIPTION
Hi,

TypeApplications is a very nice extension added in GHC 8 that lets us demonstrate on the channel how certain polymorphic function would specialize for certain types.

This is immensely valuable and I'd love to see this merged. The syntax for it is already meant to not be invasive.