### PR TITLE
Removing specific/multiple bindings by name

### DIFF
--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Eval.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Eval.hs
@@ -168,7 +168,6 @@ mergeModules (Hs.Module  head1  exports1 imports1 decls1)
         -- this is a very conservative measure... we really only even care about function names (FunBind),
         -- because we just want to sort those together so clauses can be added in the right places
         -- TODO: find out whether the [Hs.Match] can contain clauses for more than one function (e,g. might it be a whole binding group?)
-        funcNamesBound (Hs.TypeSig ms _) = ms
         funcNamesBound (Hs.FunBind ms) = nub $ sort [ n | Hs.Match n _ _ _ <- ms]
         funcNamesBound _ = []
 


### PR DESCRIPTION
This fixes issue #148.

Changes:
- @undefine now support an argument to remove a specific binding.
- @undefine now support multiple arguments to remove multiple bindings.
- @undefine remains able to clear all bindings when no arguments are given.

To accomodate the changes, the possible diagnosis texts were modified to:
- Undefined.
- Undefined everything.
- Already undefined.
- Cannot undefine because it is needed elsewhere.
- Cannot undefine because some are needed elsewhere.

It is currently able to undefine by name:
- Any function definitions as well as their accompanying type signatures.
- Any class declarations as well as their instances.
- Any type declarations.
- Any data declarations.

Example usage:

```
lambdabot> let {foo = 42; bar = foo; baz = True}
 Defined.
lambdabot> undefine baz
 Undefined.
lambdabot> undefine foo
 Cannot undefine because it is needed elsewhere.
lambdabot> undefine foo bar
 Undefined.
lambdabot> undefine
 Undefined everything.
```

Feel free to suggest any improvements. :)
