### PR TITLE
Condense messages to channel on a single line

### DIFF
--- a/lambdabot-core/src/Lambdabot/Plugin.hs
+++ b/lambdabot-core/src/Lambdabot/Plugin.hs
@@ -52,9 +52,9 @@ lim80 :: Monad m => m String -> Cmd m ()
 lim80 action = do
     to <- getTarget
     let lim = case nName to of
-                  ('#':_) -> take 3 . map (limitStr 80) -- message to channel: be nice
-                  _       -> id          -- private message: get everything
-        spaceOut = unlines . lim . map (' ':) . lines
+                  ('#':_) -> (' ':) . unwords . map (limitStr 80 . strip isSpace) . take 3 -- message to channel: be nice
+                  _       -> unlines . map (' ':) -- private message: get everything
+        spaceOut = lim . lines
         removeControl = filter (\x -> isSpace x || not (isControl x))
     (say =<<) . lift $ liftM (encodeString . spaceOut . removeControl . decodeString) action
 


### PR DESCRIPTION
Lambdabot gets used quite intensively at some times, and the 3-line error messages still cause a lot of noise IMO. 

Those who want to see the formatted error can still PM lambdabot.

Here are samples of the proposed change:

    <lambdabot>  <hint>:1:13: error:
    <lambdabot>      parse error on input ‘=’
    <lambdabot>      Perhaps you need a 'let' in a 'do' block?
    ---
    <lambdabot>  <hint>:1:13: error: parse error on input ‘=’ Perhaps you need a 'let' in a 'do' block?

    
    <lambdabot>  error:
    <lambdabot>      • Couldn't match expected type ‘(t0 a0 -> Bool) -> a0 -> Bool’
    <lambdabot>                    with actual type ‘[Integer]’
    ---
    <lambdabot>  error: • Couldn't match expected type ‘(t0 a0 -> Bool) -> a0 -> Bool' with actual type ‘[Integer]’
