### PR TITLE
A couple fixes to the source plugin

### DIFF
--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Source.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Source.hs
@@ -5,6 +5,7 @@ module Lambdabot.Plugin.Haskell.Source (sourcePlugin) where
 import Lambdabot.Plugin
 import Lambdabot.Util
 import Control.Monad
+import Data.List (sort)
 import qualified Data.ByteString.Char8 as P
 import qualified Data.Map as M
 
@@ -15,7 +16,7 @@ sourcePlugin = newModule
     { moduleCmds = return
         [ (command "src")
             { help = say helpStr
-            , process = \key -> readMS >>= \env -> case fetch (P.pack key) env of
+            , process = \key -> readMS >>= \env -> case M.lookup (normalize key) env of
                 _ | M.null env -> say "No source in the environment yet"
                 _ |   null key -> say helpStr
                 Nothing        -> say . ("Source not found. " ++) =<< randomFailureMsg
@@ -28,14 +29,13 @@ sourcePlugin = newModule
     , moduleSerialize = Just . readOnly $ M.fromList . map pair . splat . P.lines
     }
         where
-            pair (a:b) = (a, P.unlines b)
+            pair (a:b) = (normalize a, P.unlines b)
             pair _     = error "Source Plugin error: not a pair"
             splat []   = []
             splat s    = a : splat (tail b) where (a,b) = break P.null s
 
-fetch :: P.ByteString -> Env -> Maybe P.ByteString
-fetch x m = M.lookup x m `mplus`
-            M.lookup (P.concat [P.singleton '(', x, P.singleton ')']) m
+normalize :: P.ByteString -> P.ByteString
+normalize = P.unwords . sort . map (P.filter (`notElem` "()")) . P.words
 
 helpStr :: String
-helpStr = "src <id>. Display the implementation of a standard function"
+helpStr = "src <id> or src <type> <methodid>. Display the implementation of a standard function"

--- a/lambdabot/State/source
+++ b/lambdabot/State/source
@@ -634,6 +634,7 @@ listToMaybe (a:_) = Just a
 catMaybes
 catMaybes ls = [x | Just x <- ls]
 
+Either
 data Either a b = Left a | Right b
 
 either
@@ -710,6 +711,7 @@ fromDynamic (Dynamic t v) = case unsafeCoerce v of
     r | t == typeOf r -> Just r
       | otherwise     -> Nothing
 
+second
 second f = arr swap >>> first f >>> arr swap
     where swap ~(x,y) = (y,x)
 
@@ -781,6 +783,7 @@ swapMVar mvar new = block $ do
     putMVar mvar new
     return old
 
+withMVar
 withMVar m io = block $ do
     a <- takeMVar m
     b <- Exception.catch (unblock (io a)) (\e -> do putMVar m a; throw e)


### PR DESCRIPTION
Everytime I try to use `@src` on IRC to look up an instance method, I find I've forgotten the order of arguments, as well as where parentheses are needed. I just today found myself trying all 3 wrong combinations in sequence before getting it correct. So let's fix that once and for all with a `normalize` function. The function is tested but not the plugin, since I'm not going to try compiling lambdabot myself.

Also, there were some entries missing keys in the source data, which I've added.