### PR TITLE
Take user for -e as command line argument

### DIFF
--- a/lambdabot-core/src/Lambdabot/Config/Core.hs
+++ b/lambdabot-core/src/Lambdabot/Config/Core.hs
@@ -19,6 +19,7 @@ module Lambdabot.Config.Core
     , consoleLogHandle
     , consoleLogLevel
     , consoleLogFormat
+    , consoleUser
     ) where
 
 import Lambdabot.Config
@@ -51,6 +52,7 @@ config "lbRootLoggerPath"   [t| [String]                |] [| []                
 config "consoleLogHandle"   [t| Handle                  |] [| stderr                      |]
 config "consoleLogLevel"    [t| Priority                |] [| NOTICE                      |]
 config "consoleLogFormat"   [t| String                  |] [| "[$prio] $loggername: $msg" |]
+config "consoleUser"        [t| String                  |] [| "user" |]
 
 --------------------------------------------
 -- Default values with longer definitions

--- a/lambdabot-core/src/Lambdabot/Plugin/Core/OfflineRC.hs
+++ b/lambdabot-core/src/Lambdabot/Plugin/Core/OfflineRC.hs
@@ -69,6 +69,7 @@ offlineRCPlugin = newModule
 feed :: String -> OfflineRC ()
 feed msg = do
     cmdPrefix <- fmap head (getConfig commandPrefixes)
+    cmdUser <- getConfig consoleUser
     let msg' = case msg of
             '>':xs -> cmdPrefix ++ "run " ++ xs
             '!':xs -> xs
@@ -77,7 +78,7 @@ feed msg = do
     lb . void . timeout (15 * 1000 * 1000) . received $
               IrcMessage { ircMsgServer = "offlinerc"
                          , ircMsgLBName = "offline"
-                         , ircMsgPrefix = "null!n=user@null"
+                         , ircMsgPrefix = cmdUser ++ "!n=user@null"
                          , ircMsgCommand = "PRIVMSG"
                          , ircMsgParams = ["offline", ":" ++ encodeString msg' ] }
 

--- a/lambdabot/src/Main.hs
+++ b/lambdabot/src/Main.hs
@@ -27,6 +27,7 @@ flags =
     , Option "V"  ["version"] (NoArg version)                       "Print the version of lambdabot"
     , Option "X"  []        (arg "<extension>" languageExts strs)   "Set a GHC language extension for @run"
     , Option "n"  ["nice"]  (NoArg noinsult)                        "Be nice (disable insulting error messages)"
+    , Option "u"  []        (arg "<user>" consoleUser return)       "Run -e commands as given user"
     ] where 
         arg :: String -> Config t -> (String -> IO t) -> ArgDescr (IO (DSum Config Identity))
         arg descr key fn = ReqArg (fmap (key ==>) . fn) descr


### PR DESCRIPTION
When using lambdabot outside of IRC it is sometimes helpful to allow specifying as which user a command passed via -e should be issued.