### PR TITLE
Add proper support for "new-build" from cabal-install version 2.x.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Icon?
 ###########
 
 dist
+dist-newstyle
 *.o
 *.hi
 *.chi
@@ -25,6 +26,8 @@ dist
 .cabal-sandbox
 cabal.sandbox.config
 cabal.config
+.*.environment.*
+/cabal.project.local
 
 ###########
 # Editors #

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+-- cabal.project
+
+packages: */*.cabal


### PR DESCRIPTION
Just execute

    $ cabal new-build lambdabot

in the top-level of this repository to compile the bot plus all plugins in a
Nix-style sandbox environment.