### PR TITLE
Fix build with GHC 8.4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
       compiler: ": #GHC 8.2.2"
       addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5], sources: [hvr-ghc]}}
 
+    - env: CABALVER=2.2 GHCVER=8.4.3
+      compiler: ": #GHC 8.4.3"
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.3,happy-1.19.5], sources: [hvr-ghc]}}
+
 #  exclude:
 #    - env: CABALVER=1.18 GHCVER=7.8.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ install:
            $HOME/.cabal/packages/hackage.haskell.org/01-index.tar;
     fi
   - travis_retry cabal update
+  - "sed -i.bak 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config"
   - for pkg in $(ghc-pkg list --user --simple-output); do echo $pkg; done | sort | tee packages-installed
   - cabal install $CABAL_INSTALL_FLAGS --only-dependencies --global --dry-run $PACKAGES | tee packages-needed
   - sed 's/ (.*)//' packages-needed | grep -v ' ' | sort > packages-needed-sorted

--- a/lambdabot-core/src/Lambdabot/Config.hs
+++ b/lambdabot-core/src/Lambdabot/Config.hs
@@ -29,9 +29,9 @@ import Data.Typeable
 import Data.Generics (everywhere, mkT)
 import Language.Haskell.TH
 
-data Config t where Config :: (Typeable1 k, GCompare k) => !(k t) -> t -> (t -> t -> t) -> Config t
+data Config t where Config :: (Typeable k, GCompare k) => !(k t) -> t -> (t -> t -> t) -> Config t
 
-cast1 :: (Typeable1 f, Typeable1 g) => f a -> Maybe (g a)
+cast1 :: (Typeable f, Typeable g) => f a -> Maybe (g a)
 cast1 = fmap runIdentity . gcast1 . Identity
 
 instance GEq Config where

--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Free/Expr.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Free/Expr.hs
@@ -5,6 +5,8 @@ module Lambdabot.Plugin.Haskell.Free.Expr where
 import Lambdabot.Plugin.Haskell.Free.Type
 import Lambdabot.Plugin.Haskell.Free.Util
 
+import Prelude hiding ((<>))
+
 varInExpr :: Var -> Expr -> Bool
 varInExpr v (EBuiltin _)
     = False

--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Free/Theorem.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Free/Theorem.hs
@@ -6,6 +6,8 @@ import Lambdabot.Plugin.Haskell.Free.Type
 import Lambdabot.Plugin.Haskell.Free.Expr
 import Lambdabot.Plugin.Haskell.Free.Util
 
+import Prelude hiding ((<>))
+
 data Theorem
     = ThForall Var Type Theorem
     | ThImplies Theorem Theorem

--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Free/Type.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Free/Type.hs
@@ -6,6 +6,7 @@ import Control.Monad
 import Lambdabot.Plugin.Haskell.Free.Parse
 import Data.List
 import Lambdabot.Plugin.Haskell.Free.Util
+import Prelude hiding ((<>))
 
 type TyVar = String
 type TyName = String


### PR DESCRIPTION
I cherry picked the relevant commit from the `ghc-8.4.1` branch and updated Travis-CI so that it uses the new compiler, too. Test builds succeeded fine for me. The patches to 3rd party software have all been upstreamed by now -- flexible-default-0.0.2  was the last missing piece.