### PR TITLE
Switch defaultUserHooks to simpleUserHooks

### DIFF
--- a/lambdabot-core/Setup.hs
+++ b/lambdabot-core/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks simpleUserHooks

--- a/lambdabot-haskell-plugins/Setup.hs
+++ b/lambdabot-haskell-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks simpleUserHooks

--- a/lambdabot-irc-plugins/Setup.hs
+++ b/lambdabot-irc-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks simpleUserHooks

--- a/lambdabot-misc-plugins/Setup.hs
+++ b/lambdabot-misc-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks simpleUserHooks

--- a/lambdabot-novelty-plugins/Setup.hs
+++ b/lambdabot-novelty-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks simpleUserHooks

--- a/lambdabot-reference-plugins/Setup.hs
+++ b/lambdabot-reference-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks simpleUserHooks

--- a/lambdabot-social-plugins/Setup.hs
+++ b/lambdabot-social-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks simpleUserHooks

--- a/lambdabot-trusted/Setup.hs
+++ b/lambdabot-trusted/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks simpleUserHooks

--- a/lambdabot/Setup.hs
+++ b/lambdabot/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMainWithHooks simpleUserHooks


### PR DESCRIPTION
defaultUserHooks has been deprecated in Cabal for a long time. It has
recently been removed.