### PR TITLE
use `defaultMain` in Setup.hs (fixes #188)

### DIFF
--- a/lambdabot-core/Setup.hs
+++ b/lambdabot-core/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMain

--- a/lambdabot-haskell-plugins/Setup.hs
+++ b/lambdabot-haskell-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMain

--- a/lambdabot-irc-plugins/Setup.hs
+++ b/lambdabot-irc-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMain

--- a/lambdabot-misc-plugins/Setup.hs
+++ b/lambdabot-misc-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMain

--- a/lambdabot-novelty-plugins/Setup.hs
+++ b/lambdabot-novelty-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMain

--- a/lambdabot-reference-plugins/Setup.hs
+++ b/lambdabot-reference-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMain

--- a/lambdabot-social-plugins/Setup.hs
+++ b/lambdabot-social-plugins/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMain

--- a/lambdabot-trusted/Setup.hs
+++ b/lambdabot-trusted/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMain

--- a/lambdabot/Setup.hs
+++ b/lambdabot/Setup.hs
@@ -1,3 +1,3 @@
 #!/usr/bin/env runhaskell
 import Distribution.Simple
-main = defaultMainWithHooks defaultUserHooks
+main = defaultMain


### PR DESCRIPTION
- this allows Setup.hs to be built with Cabal-3.0.0.0
- based on patch by Brian McKenna (@puffnfresh)