### PR TITLE
UTF-8 fix in @check

### DIFF
--- a/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Check.hs
+++ b/lambdabot-haskell-plugins/src/Lambdabot/Plugin/Haskell/Check.hs
@@ -7,6 +7,7 @@ module Lambdabot.Plugin.Haskell.Check (checkPlugin) where
 import Lambdabot.Plugin
 import Lambdabot.Plugin.Haskell.Eval (runGHC)
 import qualified Language.Haskell.Exts.Simple as Hs
+import Codec.Binary.UTF8.String
 
 checkPlugin :: Module ()
 checkPlugin = newModule
@@ -22,7 +23,7 @@ checkPlugin = newModule
 
 check :: MonadLB m => String -> m String
 check src =
-    case Hs.parseExp src of
+    case Hs.parseExp (decodeString src) of
         Hs.ParseFailed l e  -> return (Hs.prettyPrint l ++ ':' : e)
         Hs.ParseOk{}        -> postProcess `fmap` runGHC ("text (myquickcheck (" ++ src ++ "))")
 


### PR DESCRIPTION
Old behaviour:
```
@check \ä -> ä == ()
 <unknown>.hs:1:3:Parse error: �
```

New behavior:
```
@check \ä -> ä == ()
 +++ OK, passed 100 tests.
```