### PR TITLE
Fix lambdabot-core for dependent-map 0.4

### DIFF
--- a/lambdabot-core/lambdabot-core.cabal
+++ b/lambdabot-core/lambdabot-core.cabal
@@ -72,7 +72,7 @@ library
                         binary                  >= 0.5,
                         bytestring              >= 0.9,
                         containers              >= 0.4,
-                        dependent-map           >= 0.2 && < 0.4,
+                        dependent-map           >= 0.2 && < 0.5,
                         dependent-sum           >= 0.7 && < 0.8,
                         dependent-sum-template  >= 0.1.0.2 && < 0.2,
                         directory               >= 1.1,

--- a/lambdabot-core/src/Lambdabot/Monad.hs
+++ b/lambdabot-core/src/Lambdabot/Monad.hs
@@ -88,7 +88,7 @@ data IRCRState = IRCRState
     }
 
 -- | Default ro state
-initRoState :: [D.DSum Config Identity] -> IO IRCRState
+initRoState :: [DSum Config Identity] -> IO IRCRState
 initRoState configuration = do
     quitMVar     <- newEmptyMVar
     initDoneMVar <- newEmptyMVar


### PR DESCRIPTION
dependent-map 0.4 stopped re-exporting DSum from dependent-sum,
but dependent-sum is already imported unqualified so just use
that.