### PR TITLE
where: when data is empty, delete the fact

### DIFF
--- a/lambdabot-reference-plugins/src/Lambdabot/Plugin/Reference/Where.hs
+++ b/lambdabot-reference-plugins/src/Lambdabot/Plugin/Reference/Where.hs
@@ -69,6 +69,10 @@ getWhere fm fact =
         Just x  -> P.unpack x
 
 updateWhere :: Bool -> WhereState -> WhereWriter -> String -> String -> Cmd Where String
-updateWhere _guard factFM writer fact dat = do
+updateWhere _guard factFM writer fact dat
+    | null dat = do
+        writer $ M.delete (P.pack fact) factFM
+        return "It is forgotten."
+    | otherwise = do
         writer $ M.insert (P.pack fact) (P.pack dat) factFM
         randomSuccessMsg


### PR DESCRIPTION
`@where+ FACT` currently leaves the fact in the db with empty data. This has led to some cruft buildup, including some very long fact ids that make it a bit hard to format the db as a table. This change allows facts to be removed entirely.