### PR TITLE
poll: preserve unicode characters, and some cleanup

### DIFF
--- a/lambdabot-core/src/Lambdabot/Util/Serial.hs
+++ b/lambdabot-core/src/Lambdabot/Util/Serial.hs
@@ -132,10 +132,12 @@ instance Packable ([(ByteString,ByteString)]) where
 
         showPacked = gzip . P.unlines . concatMap (\(k,v) -> [k,v])
 
-instance Packable (M.Map P.ByteString (Bool, [(String, Int)])) where
+-- The following instance is used by the `poll` plugin.
+-- The `read` and `show` are there for backward compatibility.
+instance Packable (M.Map P.ByteString (Bool, [(P.ByteString, Int)])) where
     readPacked = M.fromList . readKV . P.lines
         where
-          readKV :: [P.ByteString] -> [(P.ByteString,(Bool, [(String, Int)]))]
+          readKV :: [P.ByteString] -> [(P.ByteString,(Bool, [(P.ByteString, Int)]))]
           readKV []         = []
           readKV (k:v:rest) = (k, (read . P.unpack) v) : readKV rest
           readKV _          = error "Vote.readPacked: parse failed"


### PR DESCRIPTION
As pointed out by @l29ah in #184, the `poll` plugin does not handle Unicode well. For example,
```
<int-e> @poll-show äöü
<lambdabot> No such poll: "\195\164\195\182\195\188" Use @poll-list to see the available polls.
```
With this PR, Unicode is preserved:
```
<lambdabot> No such poll: "äöü" Use @poll-list to see the available polls.
```