### PR TITLE
lambdabot: add NoGeneralizedNewtypeDeriving to default Pristine.hs

### DIFF
--- a/lambdabot/State/Pristine.hs.default
+++ b/lambdabot/State/Pristine.hs.default
@@ -1,4 +1,5 @@
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE NoGeneralizedNewtypeDeriving #-} -- necessary with Safe, see ghc#19605
 
 {-# LANGUAGE ConstrainedClassMethods #-}
 {-# LANGUAGE DeriveDataTypeable #-}


### PR DESCRIPTION
Works around https://gitlab.haskell.org/ghc/ghc/-/issues/19605#note_567370